### PR TITLE
Fix change-request submission under MediaWiki 1.43

### DIFF
--- a/includes/ApiKZChangeRequest.php
+++ b/includes/ApiKZChangeRequest.php
@@ -2,16 +2,16 @@
 
 namespace MediaWiki\Extension\KZChangeRequest;
 
-use ApiBase;
+use MediaWiki\Api\ApiBase;
 use Exception;
 use MediaWiki\Json\FormatJson;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
-use MediaWiki\Page\WikiPage;
+use WikiPage;
 use MediaWiki\Registration\ExtensionRegistry;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
-use Sanitizer;
+use MediaWiki\Parser\Sanitizer;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class ApiKZChangeRequest extends ApiBase {
@@ -37,8 +37,10 @@ class ApiKZChangeRequest extends ApiBase {
 			$this->dieWithError( 'kzchangerequest-captcha-fail' );
 		}
 
-		// Get page info
-		$page = WikiPage::newFromID( $params['articleId'] );
+		// Get page info. WikiPage::newFromID() was removed in MediaWiki 1.43;
+		// use the WikiPageFactory service instead.
+		$page = MediaWikiServices::getInstance()->getWikiPageFactory()
+			->newFromID( $params['articleId'] );
 		if ( !$page ) {
 			$this->dieWithError( 'kzchangerequest-invalid-page' );
 		}
@@ -208,7 +210,7 @@ class ApiKZChangeRequest extends ApiBase {
 			if ( !$status->isOK() ) {
 				$this->logger->error(
 					"Jira customer query callout failed with message: {errorMsg}, email={email}",
-					[ 'errorMsg' => $status->getMessage()->toString(), 'email' => $email ]
+					[ 'errorMsg' => $this->formatStatus( $status ), 'email' => $email ]
 				);
 				return null;
 			}
@@ -228,6 +230,22 @@ class ApiKZChangeRequest extends ApiBase {
 			);
 			return null;
 		}
+	}
+
+	/**
+	 * Format an HTTP-request Status into plain text for logging.
+	 *
+	 * MWHttpRequest::execute() returns a Status; reading it via the deprecated
+	 * Status::getMessage()->toString() breaks under MediaWiki 1.42+ (getMessage
+	 * is deprecated in favour of StatusFormatter, and Message::toString() now
+	 * requires a format argument). Use the StatusFormatter service instead.
+	 *
+	 * @param \StatusValue $status
+	 * @return string
+	 */
+	private function formatStatus( $status ): string {
+		return MediaWikiServices::getInstance()->getFormatterFactory()
+			->getStatusFormatter( $this )->getWikiText( $status );
 	}
 
 	/**
@@ -256,7 +274,7 @@ class ApiKZChangeRequest extends ApiBase {
 			if ( !$status->isOK() ) {
 				$this->logger->error(
 					"Jira ticket creation failed with message: {errorMsg}, issueData={issueData}",
-					[ 'errorMsg' => $status->getMessage()->toString(), 'issueData' => $postJson ]
+					[ 'errorMsg' => $this->formatStatus( $status ), 'issueData' => $postJson ]
 				);
 				return false;
 			}
@@ -312,7 +330,7 @@ class ApiKZChangeRequest extends ApiBase {
 			if ( !$status->isOK() ) {
 				$this->logger->error(
 					"ReCAPTCHA validation failed with message: {errorMsg}",
-					[ 'errorMsg' => $status->getMessage()->toString() ]
+					[ 'errorMsg' => $this->formatStatus( $status ) ]
 				);
 				return false;
 			}

--- a/includes/ApiKZChangeRequest.php
+++ b/includes/ApiKZChangeRequest.php
@@ -386,13 +386,13 @@ class ApiKZChangeRequest extends ApiBase {
 		 * @return array
 		 */
 	private function getPageLanguageLinks( int $articleId ): array {
-		$dbr = wfGetDB( DB_REPLICA );
-		$res = $dbr->select(
-			'langlinks',
-			[ 'll_lang', 'll_title' ],
-			[ 'll_from' => $articleId ],
-			__METHOD__
-		);
+		$dbr = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
+		$res = $dbr->newSelectQueryBuilder()
+			->select( [ 'll_lang', 'll_title' ] )
+			->from( 'langlinks' )
+			->where( [ 'll_from' => $articleId ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$links = [];
 		foreach ( $res as $row ) {


### PR DESCRIPTION
## Problem

Every change-request submission on the MW 1.43 stack failed with a generic
"internal system error" (`kzchangerequest-submission-error`). The integration
was effectively dead since the 1.43 upgrade. Two distinct removed/changed-API
faults were responsible, each masked from the logs:

1. **`WikiPage::newFromID()` removed in 1.43.** Called in `execute()` before any
   Jira work, it threw a PHP `Error` (`Call to undefined method`) — outside the
   `try`, so it surfaced as an opaque `internal_api_error_Error`. Fixed by
   resolving the page via the `WikiPageFactory` service.

2. **`Status::getMessage()->toString()` broken on 1.42+.** Three call sites
   (customer lookup, ticket create, reCAPTCHA verify) read an HTTP-request
   `Status` this way. `Status::getMessage()` is deprecated since 1.42 in favour
   of `StatusFormatter`, and `Message::toString()` now *requires* a `$format`
   argument — so the arg-less call throws `ArgumentCountError`. Because that
   throw happens while evaluating a `logger->error()` argument **on the failure
   path**, the real Jira error was never logged and (being an `Error`, not an
   `Exception`) escaped the surrounding `catch`. Routed all three through the
   `StatusFormatter` service so failures degrade gracefully and are logged.

Also modernised the deprecated-since-1.39 `wfGetDB( DB_REPLICA )` to the
`ConnectionProvider` + `SelectQueryBuilder` idiom (separate commit).

## Verification

Hot-deployed to the staging container and exercised the **real browser flow**
on `staging-test.wikirights.org.il` (form → reCAPTCHA v3 → submit): the request
now succeeds and a ticket lands in the correct **STAG** service desk
(`serviceDeskId 3` / `requestTypeId 13`). Credentials/queue-routing were
independently confirmed by direct service-desk POSTs.

Refs kolzchut/kz-infrastructure#313