### PR TITLE
Add Playwright e2e suite for the change-request form

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/package-lock.json
+/playwright-report
+/test-results

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,45 @@
+# KZChangeRequest e2e tests
+
+Playwright suite for the change-request ("suggest a change" / הציעו שינוי) form.
+
+The form is anonymous and appears on every content article, so the specs land
+on `Special:Random` and need no login.
+
+## Run
+
+```sh
+npm install --ignore-scripts
+npx playwright install chromium   # first time only
+
+# Local dev (main site):
+npx playwright test
+
+# Staging:
+MW_BASE_URL=https://staging-test.wikirights.org.il MW_SCRIPT_PATH=/he \
+  npx playwright test
+```
+
+The platform runner `kz-infrastructure/tests/run-extension-e2e.sh` discovers and
+runs this suite automatically (it lives next to `playwright.config.ts`).
+
+### Environment
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `MW_BASE_URL` | `http://localhost:8082` | Wiki base URL |
+| `MW_SCRIPT_PATH` | `/he` | Article-path prefix (language root) |
+
+## What it covers — and the Turnstile caveat
+
+1. **Front-end wiring** — the button opens the OOUI dialog with the request +
+   contact fields and a submit action. Runs anywhere.
+
+2. **The Cloudflare Turnstile gate.** Where a sitekey is configured
+   (staging / prod) the widget bootstraps, but a **headless/automated browser
+   cannot pass Cloudflare's bot attestation** — the Private Access Token /
+   challenge flow fails and no token is minted, so the submission is gated.
+   This is asserted, not worked around: it is the captcha doing its job.
+   Consequently **there is no fully-automated happy-path submission** — a real
+   end-to-end (solve → Jira ticket) needs a human solving the challenge, or the
+   Jira half exercised server-side. In local dev, where no sitekey is set, this
+   spec skips cleanly.

--- a/tests/e2e/change-request-form.spec.ts
+++ b/tests/e2e/change-request-form.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * KZChangeRequest — the "suggest a change" (הציעו שינוי) form.
+ *
+ * The form is anonymous and rendered on every content article, so these specs
+ * land on Special:Random and need no login. They cover two things:
+ *
+ *  1. Front-end wiring — the button opens the OOUI dialog with the request +
+ *     contact fields. Environment-independent.
+ *
+ *  2. The Cloudflare Turnstile gate. Where a sitekey is configured (staging /
+ *     prod) the widget bootstraps, but a headless/automated browser cannot
+ *     pass Cloudflare's bot attestation — the Private Access Token / challenge
+ *     flow fails and NO token is minted. Combined with the server's
+ *     fail-closed check, the submission is gated. This is asserted, not worked
+ *     around: it is the captcha doing its job, and it is why there is no
+ *     fully-automated happy-path submission. In local dev, where no sitekey is
+ *     set, that spec skips cleanly (never silently passes).
+ *
+ * Run (local dev):   npx playwright test
+ * Run (staging):     MW_BASE_URL=https://staging-test.wikirights.org.il \
+ *                      MW_SCRIPT_PATH=/he npx playwright test
+ */
+
+const SCRIPT_PATH = process.env.MW_SCRIPT_PATH || '/he';
+
+async function openDialog(page: Page) {
+  const button = page.locator('.changerequest-btn');
+  await expect(button, 'the "suggest a change" button should render on a content article').toBeVisible();
+  await button.click();
+  const dialog = page.locator('.kzchangerequest-dialog');
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test.describe('KZChangeRequest change-request form', () => {
+  // Collect uncaught page errors so a broken form module is caught, but only
+  // fail on errors from this extension — content articles carry unrelated
+  // gadgets (TTS, ranking, third-party captcha) whose noise is not under test.
+  let ownErrors: string[];
+
+  test.beforeEach(async ({ page }) => {
+    ownErrors = [];
+    page.on('pageerror', (err) => {
+      const message = String(err);
+      if (/kzchangerequest/i.test(message)) ownErrors.push(message);
+    });
+    // A random content article always carries the change-request button.
+    await page.goto(`${SCRIPT_PATH}/Special:Random`, { waitUntil: 'domcontentloaded' });
+  });
+
+  test('button opens a dialog with request + contact fields', async ({ page }) => {
+    const dialog = await openDialog(page);
+
+    // Required free-text request field.
+    await expect(dialog.locator('textarea')).toBeVisible();
+
+    // Two contact inputs (name + email).
+    const contactInputs = dialog.locator('input[type="text"], input[type="email"], input:not([type])');
+    expect(await contactInputs.count(), 'name + email contact inputs').toBeGreaterThanOrEqual(2);
+
+    expect(ownErrors, `KZChangeRequest page errors: ${ownErrors.join('; ')}`).toHaveLength(0);
+  });
+
+  test('Turnstile is wired in and gates submission for an automated browser', async ({ page }) => {
+    let contactedTurnstile = false;
+    page.on('request', (req) => {
+      if (req.url().includes('challenges.cloudflare.com')) contactedTurnstile = true;
+    });
+
+    const dialog = await openDialog(page);
+
+    // The Turnstile mount point is always present in the dialog markup.
+    await expect(dialog.locator('.kzcr-turnstile')).toBeAttached();
+
+    // Give the widget a chance to bootstrap.
+    await page.waitForTimeout(6000);
+
+    // No sitekey configured for this environment (e.g. local dev) → nothing to
+    // assert about the gate. Skip rather than silently pass.
+    test.skip(!contactedTurnstile, 'No Turnstile sitekey configured for this environment (e.g. local dev).');
+
+    // Fill the required field so form-validity is not what blocks submission.
+    await dialog.locator('textarea').fill('e2e wiring check — please ignore');
+
+    // The widget bootstrapped, but an automated browser cannot solve Cloudflare's
+    // bot attestation, so no token is minted…
+    const token = await dialog
+      .locator('[name="cf-turnstile-response"]')
+      .inputValue()
+      .catch(() => '');
+    expect(token, 'Turnstile must not issue a token to an automated browser').toBe('');
+
+    // …so a submit attempt never reaches the success/confirmation panel (which
+    // is pre-rendered in the DOM but stays hidden until a real submission).
+    await page.evaluate(() => {
+      const primary = document.querySelector(
+        '.oo-ui-processDialog-actions-primary a[role="button"], .oo-ui-processDialog-actions-primary button'
+      ) as HTMLElement | null;
+      if (primary && !primary.classList.contains('oo-ui-widget-disabled')) primary.click();
+    });
+    await page.waitForTimeout(3000);
+    await expect(page.locator('.kzchangerequest-success')).toBeHidden();
+  });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "kzchangerequest-extension-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright e2e suite for the KZChangeRequest change-request form (dialog + Turnstile wiring).",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "typecheck": "tsc --noEmit",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for the KZChangeRequest change-request form e2e tests.
+ *
+ * Run:
+ *   npx playwright test
+ *   npx playwright test --headed
+ *
+ * Environment variables:
+ *   MW_BASE_URL    - MediaWiki base URL (default: http://localhost:8082)
+ *   MW_SCRIPT_PATH - article-path prefix, i.e. the wiki language root
+ *                    (default: /he). The change-request form is anonymous, so
+ *                    no MW_USERNAME / MW_PASSWORD are needed.
+ *
+ * The change-request button appears on content articles; the specs land on
+ * Special:Random so they don't depend on any particular page existing.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: ['**/*.spec.ts'],
+  timeout: 45000,
+  expect: { timeout: 10000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+
+  reporter: [
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ['list'],
+  ],
+
+  use: {
+    baseURL: process.env.MW_BASE_URL || 'http://localhost:8082',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'kzcr-desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+  ],
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["e2e/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
Adds the first Playwright e2e suite for the extension, following the platform convention (each extension ships its own `tests/` suite; `kz-infrastructure/tests/run-extension-e2e.sh` discovers it). Complements the PHPUnit `ValidateTurnstileTest` (server-side) with the client/UI side.

Anonymous suite (no login) landing on `Special:Random`:
1. **Front-end wiring** — the button opens the OOUI dialog with the request + contact fields.
2. **The Turnstile gate** — where a sitekey is configured (staging/prod) the widget bootstraps, but a **headless/automated browser cannot pass Cloudflare's bot attestation** (the PAT/challenge flow fails, `net::ERR_ABORTED` on the challenge iframe, 401 on the PAT endpoint), so **no token is minted** and the submission never reaches the success panel. This is asserted, not worked around — it is the captcha doing its job, and is why there is no fully-automated happy-path submission. Skips cleanly in local dev (no sitekey).

Reads the standard `MW_BASE_URL` / `MW_SCRIPT_PATH` env; `tsc --noEmit` clean; **verified green against staging** (`staging-test.wikirights.org.il`).

Context: client-side companion to the KZChangeRequest security review (PR #7 / issue #6). The full solve→Jira e2e still needs a human solve or a server-side exercise of the Jira half.